### PR TITLE
Add configurable PerfectCue overlay controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Please consider supporting the original clock-8001 development: https://www.payp
 
 - Runtime: runs headless via KMSDRM (no X11/Wayland)
 - Features: added "quad" and "dual" text clock faces
+- Features: added configurable PerfectCue overlay placement/size in the web UI, plus a built-in test button for previewing the overlay without hardware
 - Features: refactored `alsa-ltc` binary for 64-bit Trixie
 - Features: retained GPIO pulse output support (`periph.io`)
 - Platform: targets Raspberry Pi 5 running Raspberry Pi OS Lite (64-bit) / Debian Trixie (arm64)

--- a/v4/cmd/sdl-clock/config.html.go
+++ b/v4/cmd/sdl-clock/config.html.go
@@ -512,11 +512,8 @@ const configHTML = `
                 <legend>DSAN Perfect Cue</legend>
                 <p>See the documentation in perfectcue.md for required hardware.</p>
 
-                <p>Use these buttons to test cue overlays without Perfect Cue hardware.</p>
-                <input type="button" value="Test Right Cue" onclick="sendCueTest('right')" />
-                <input type="button" value="Test Left Cue" onclick="sendCueTest('left')" />
-                <input type="button" value="Test Blank On" onclick="sendCueTest('blank_on')" />
-                <input type="button" value="Test Blank Off" onclick="sendCueTest('blank_off')" />
+                <p>Use this button to test cue overlay rendering without Perfect Cue hardware.</p>
+                <input type="button" value="Test" onclick="sendCueTest()" />
                 <span id="cue-test-status"></span>
 
                 {{checkbox "cue-enabled" "Enable Perfect Cue integration" .EngineOptions.CueEnabled}}
@@ -534,6 +531,10 @@ const configHTML = `
                 {{text "cue-serial" "Serial port for communication with the Perfect Cue" .EngineOptions.CueSerial}}
                 {{number "cue-duration" "Time to show the cue marks on screen, in seconds" .EngineOptions.CueDuration}}
                 {{checkbox "cue-fullscreen" "Show the cue information as full screen icons" .CueFullScreen}}
+                {{number "cue-pos-x" "Cue overlay X position in pixels (used when fullscreen mode is off)" .CuePosX}}
+                {{number "cue-pos-y" "Cue overlay Y position in pixels (used when fullscreen mode is off)" .CuePosY}}
+                {{number "cue-width" "Cue overlay width in pixels (used when fullscreen mode is off)" .CueWidth}}
+                {{number "cue-height" "Cue overlay height in pixels (used when fullscreen mode is off)" .CueHeight}}
               </fieldset>
 
               <fieldset>
@@ -955,7 +956,7 @@ const configHTML = `
       xhr.send('time=' + encodeURIComponent(ts));
     }
 
-    function sendCueTest(action) {
+    function sendCueTest() {
       var status = document.getElementById('cue-test-status');
       status.textContent = 'Sending cue test...';
       status.style.color = '{{$color}}';
@@ -965,7 +966,7 @@ const configHTML = `
       xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
       xhr.onload = function() {
         if (xhr.status === 200) {
-          status.textContent = 'Cue test sent: ' + action;
+          status.textContent = 'Cue test sent';
           status.style.color = 'green';
         } else {
           status.textContent = 'Cue test failed: ' + xhr.responseText;
@@ -976,7 +977,7 @@ const configHTML = `
         status.textContent = 'Cue test failed: network error';
         status.style.color = 'red';
       };
-      xhr.send('action=' + encodeURIComponent(action));
+      xhr.send('action=right');
     }
     </script>
   </body>

--- a/v4/cmd/sdl-clock/config.html.go
+++ b/v4/cmd/sdl-clock/config.html.go
@@ -512,6 +512,13 @@ const configHTML = `
                 <legend>DSAN Perfect Cue</legend>
                 <p>See the documentation in perfectcue.md for required hardware.</p>
 
+                <p>Use these buttons to test cue overlays without Perfect Cue hardware.</p>
+                <input type="button" value="Test Right Cue" onclick="sendCueTest('right')" />
+                <input type="button" value="Test Left Cue" onclick="sendCueTest('left')" />
+                <input type="button" value="Test Blank On" onclick="sendCueTest('blank_on')" />
+                <input type="button" value="Test Blank Off" onclick="sendCueTest('blank_off')" />
+                <span id="cue-test-status"></span>
+
                 {{checkbox "cue-enabled" "Enable Perfect Cue integration" .EngineOptions.CueEnabled}}
 
                 {{ if .Serials }}
@@ -946,6 +953,30 @@ const configHTML = `
         btn.disabled = false;
       };
       xhr.send('time=' + encodeURIComponent(ts));
+    }
+
+    function sendCueTest(action) {
+      var status = document.getElementById('cue-test-status');
+      status.textContent = 'Sending cue test...';
+      status.style.color = '{{$color}}';
+
+      var xhr = new XMLHttpRequest();
+      xhr.open('POST', '/api/cue');
+      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+      xhr.onload = function() {
+        if (xhr.status === 200) {
+          status.textContent = 'Cue test sent: ' + action;
+          status.style.color = 'green';
+        } else {
+          status.textContent = 'Cue test failed: ' + xhr.responseText;
+          status.style.color = 'red';
+        }
+      };
+      xhr.onerror = function() {
+        status.textContent = 'Cue test failed: network error';
+        status.style.color = 'red';
+      };
+      xhr.send('action=' + encodeURIComponent(action));
     }
     </script>
   </body>

--- a/v4/cmd/sdl-clock/config.html.go
+++ b/v4/cmd/sdl-clock/config.html.go
@@ -512,10 +512,6 @@ const configHTML = `
                 <legend>DSAN PerfectCue</legend>
                 <p>See the documentation in perfectcue.md for required hardware.</p>
 
-                <p>Use this button to test cue overlay rendering without PerfectCue hardware.</p>
-                <input type="button" value="Test" onclick="sendCueTest()" />
-                <span id="cue-test-status"></span>
-
                 {{checkbox "cue-enabled" "Enable PerfectCue integration" .EngineOptions.CueEnabled}}
 
                 {{ if .Serials }}
@@ -535,6 +531,10 @@ const configHTML = `
                 {{number "cue-pos-x" "Cue overlay X position in pixels" .CuePosX}}
                 {{number "cue-pos-y" "Cue overlay Y position in pixels" .CuePosY}}
                 {{number "cue-size" "Cue overlay square size in pixels" .CueSize}}
+
+                <p>Use this button to test cue overlay rendering without PerfectCue hardware.</p>
+                <input type="button" value="Test" onclick="sendCueTest()" />
+                <span id="cue-test-status"></span>
               </fieldset>
 
               <fieldset>

--- a/v4/cmd/sdl-clock/config.html.go
+++ b/v4/cmd/sdl-clock/config.html.go
@@ -509,14 +509,14 @@ const configHTML = `
               </fieldset>
 
               <fieldset>
-                <legend>DSAN Perfect Cue</legend>
+                <legend>DSAN PerfectCue</legend>
                 <p>See the documentation in perfectcue.md for required hardware.</p>
 
-                <p>Use this button to test cue overlay rendering without Perfect Cue hardware.</p>
+                <p>Use this button to test cue overlay rendering without PerfectCue hardware.</p>
                 <input type="button" value="Test" onclick="sendCueTest()" />
                 <span id="cue-test-status"></span>
 
-                {{checkbox "cue-enabled" "Enable Perfect Cue integration" .EngineOptions.CueEnabled}}
+                {{checkbox "cue-enabled" "Enable PerfectCue integration" .EngineOptions.CueEnabled}}
 
                 {{ if .Serials }}
                   <p>Detected serial devices:
@@ -528,13 +528,13 @@ const configHTML = `
                   </p>
                 {{ end }}
 
-                {{text "cue-serial" "Serial port for communication with the Perfect Cue" .EngineOptions.CueSerial}}
+                {{text "cue-serial" "Serial port for communication with PerfectCue" .EngineOptions.CueSerial}}
                 {{number "cue-duration" "Time to show the cue marks on screen, in seconds" .EngineOptions.CueDuration}}
                 {{checkbox "cue-fullscreen" "Show the cue information as full screen icons" .CueFullScreen}}
-                {{number "cue-pos-x" "Cue overlay X position in pixels (used when fullscreen mode is off)" .CuePosX}}
-                {{number "cue-pos-y" "Cue overlay Y position in pixels (used when fullscreen mode is off)" .CuePosY}}
-                {{number "cue-width" "Cue overlay width in pixels (used when fullscreen mode is off)" .CueWidth}}
-                {{number "cue-height" "Cue overlay height in pixels (used when fullscreen mode is off)" .CueHeight}}
+                <h4>Use the following when full screen is off.</h4>
+                {{number "cue-pos-x" "Cue overlay X position in pixels" .CuePosX}}
+                {{number "cue-pos-y" "Cue overlay Y position in pixels" .CuePosY}}
+                {{number "cue-size" "Cue overlay square size in pixels" .CueSize}}
               </fieldset>
 
               <fieldset>

--- a/v4/cmd/sdl-clock/config.ini.go
+++ b/v4/cmd/sdl-clock/config.ini.go
@@ -361,6 +361,10 @@ cue-enabled={{.EngineOptions.CueEnabled}}
 cue-serial={{.EngineOptions.CueSerial}}
 cue-duration={{.EngineOptions.CueDuration}}
 cue-fullscreen={{.CueFullScreen}}
+cue-pos-x={{.CuePosX}}
+cue-pos-y={{.CuePosY}}
+cue-width={{.CueWidth}}
+cue-height={{.CueHeight}}
 
 # Hyperdeck
 hyperdeck-enabled={{.EngineOptions.HyperdeckEnabled}}

--- a/v4/cmd/sdl-clock/config.ini.go
+++ b/v4/cmd/sdl-clock/config.ini.go
@@ -363,8 +363,7 @@ cue-duration={{.EngineOptions.CueDuration}}
 cue-fullscreen={{.CueFullScreen}}
 cue-pos-x={{.CuePosX}}
 cue-pos-y={{.CuePosY}}
-cue-width={{.CueWidth}}
-cue-height={{.CueHeight}}
+cue-size={{.CueSize}}
 
 # Hyperdeck
 hyperdeck-enabled={{.EngineOptions.HyperdeckEnabled}}

--- a/v4/cmd/sdl-clock/cue.go
+++ b/v4/cmd/sdl-clock/cue.go
@@ -70,6 +70,11 @@ func updateCue(state *clock.State) {
 }
 
 func drawCue() {
+	canvasW, canvasH := renderer.GetLogicalSize()
+	if canvasW <= 0 || canvasH <= 0 {
+		canvasW, canvasH, _ = renderer.GetOutputSize()
+	}
+
 	clamp := func(v, min, max int32) int32 {
 		if v < min {
 			return min
@@ -92,15 +97,15 @@ func drawCue() {
 		if h < 1 {
 			h = 1
 		}
-		if w > winWidth {
-			w = winWidth
+		if w > canvasW {
+			w = canvasW
 		}
-		if h > winHeight {
-			h = winHeight
+		if h > canvasH {
+			h = canvasH
 		}
 
-		x = clamp(x, 0, winWidth-w)
-		y = clamp(y, 0, winHeight-h)
+		x = clamp(x, 0, canvasW-w)
+		y = clamp(y, 0, canvasH-h)
 
 		return sdl.Rect{X: x, Y: y, W: w, H: h}
 	}
@@ -108,7 +113,7 @@ func drawCue() {
 	if options.CueFullScreen {
 
 		// Keep legacy fullscreen behavior unchanged when cue-fullscreen is enabled.
-		rect := sdl.Rect{X: 10, Y: 10, W: winWidth - 20, H: winHeight - 20}
+		rect := sdl.Rect{X: 10, Y: 10, W: canvasW - 20, H: canvasH - 20}
 		if rect.W < 1 {
 			rect.W = 1
 		}

--- a/v4/cmd/sdl-clock/cue.go
+++ b/v4/cmd/sdl-clock/cue.go
@@ -88,8 +88,9 @@ func drawCue() {
 	computeRect := func() sdl.Rect {
 		x := int32(options.CuePosX)
 		y := int32(options.CuePosY)
-		w := int32(options.CueWidth)
-		h := int32(options.CueHeight)
+		s := int32(options.CueSize)
+		w := s
+		h := s
 
 		if w < 1 {
 			w = 1

--- a/v4/cmd/sdl-clock/cue.go
+++ b/v4/cmd/sdl-clock/cue.go
@@ -70,22 +70,54 @@ func updateCue(state *clock.State) {
 }
 
 func drawCue() {
+	clamp := func(v, min, max int32) int32 {
+		if v < min {
+			return min
+		}
+		if v > max {
+			return max
+		}
+		return v
+	}
+
+	computeRect := func() sdl.Rect {
+		x := int32(options.CuePosX)
+		y := int32(options.CuePosY)
+		w := int32(options.CueWidth)
+		h := int32(options.CueHeight)
+
+		if w < 1 {
+			w = 1
+		}
+		if h < 1 {
+			h = 1
+		}
+		if w > winWidth {
+			w = winWidth
+		}
+		if h > winHeight {
+			h = winHeight
+		}
+
+		x = clamp(x, 0, winWidth-w)
+		y = clamp(y, 0, winHeight-h)
+
+		return sdl.Rect{X: x, Y: y, W: w, H: h}
+	}
+
 	if options.CueFullScreen {
 
-		rect := sdl.Rect{
-			W: 1920 - 20,
-			H: 1080 - 20,
-			X: 10,
-			Y: 10,
+		// Keep legacy fullscreen behavior unchanged when cue-fullscreen is enabled.
+		rect := sdl.Rect{X: 10, Y: 10, W: winWidth - 20, H: winHeight - 20}
+		if rect.W < 1 {
+			rect.W = 1
+		}
+		if rect.H < 1 {
+			rect.H = 1
 		}
 		copyIntoRect(cueTexture, rect)
 	} else {
-		rect := sdl.Rect{
-			H: 150,
-			W: 150,
-			X: 5,
-			Y: 1080 - 155,
-		}
+		rect := computeRect()
 		copyIntoRect(cueTexture, rect)
 	}
 

--- a/v4/cmd/sdl-clock/data.go
+++ b/v4/cmd/sdl-clock/data.go
@@ -114,6 +114,10 @@ type clockOptions struct {
 	CountdownTarget string `long:"countdown-target" default:"2020-12-24 00:00:00"`
 
 	CueFullScreen bool `long:"cue-fullscreen" description:"Show cue changes as full screen icons"`
+	CuePosX       int  `long:"cue-pos-x" description:"Perfect Cue overlay X position in pixels" default:"5"`
+	CuePosY       int  `long:"cue-pos-y" description:"Perfect Cue overlay Y position in pixels" default:"925"`
+	CueWidth      int  `long:"cue-width" description:"Perfect Cue overlay width in pixels" default:"150"`
+	CueHeight     int  `long:"cue-height" description:"Perfect Cue overlay height in pixels" default:"150"`
 
 	DynamicBG bool `long:"dynamic-bg"`
 

--- a/v4/cmd/sdl-clock/data.go
+++ b/v4/cmd/sdl-clock/data.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"gitlab.com/clock-8001/clock-8001/v4/clock"
-	"gitlab.com/clock-8001/clock-8001/v4/util"
 	htmlTemplate "html/template"
 	"image/color"
+
+	"gitlab.com/clock-8001/clock-8001/v4/clock"
+	"gitlab.com/clock-8001/clock-8001/v4/util"
 )
 
 var winTitle = "SDL CLOCK"
@@ -116,8 +117,11 @@ type clockOptions struct {
 	CueFullScreen bool `long:"cue-fullscreen" description:"Show cue changes as full screen icons"`
 	CuePosX       int  `long:"cue-pos-x" description:"Perfect Cue overlay X position in pixels" default:"5"`
 	CuePosY       int  `long:"cue-pos-y" description:"Perfect Cue overlay Y position in pixels" default:"925"`
-	CueWidth      int  `long:"cue-width" description:"Perfect Cue overlay width in pixels" default:"150"`
-	CueHeight     int  `long:"cue-height" description:"Perfect Cue overlay height in pixels" default:"150"`
+	CueSize       int  `long:"cue-size" description:"Perfect Cue overlay square size in pixels"`
+
+	// Legacy options retained for backward compatibility with older config files.
+	CueWidth  int `long:"cue-width" description:"Perfect Cue overlay width in pixels" default:"150"`
+	CueHeight int `long:"cue-height" description:"Perfect Cue overlay height in pixels" default:"150"`
 
 	DynamicBG bool `long:"dynamic-bg"`
 

--- a/v4/cmd/sdl-clock/http.go
+++ b/v4/cmd/sdl-clock/http.go
@@ -229,6 +229,30 @@ func saveHandler(w http.ResponseWriter, r *http.Request) {
 	newOptions.DynamicBG = r.FormValue("DynamicBG") != ""
 	newOptions.VFD = r.FormValue("VFD") != ""
 
+	newOptions.CuePosX, err = strconv.Atoi(r.FormValue("cue-pos-x"))
+	errors += util.ValidateNumber(err, "Perfect Cue X position")
+	if err == nil && newOptions.CuePosX < 0 {
+		errors += "<li>Perfect Cue X position must be 0 or greater</li>"
+	}
+
+	newOptions.CuePosY, err = strconv.Atoi(r.FormValue("cue-pos-y"))
+	errors += util.ValidateNumber(err, "Perfect Cue Y position")
+	if err == nil && newOptions.CuePosY < 0 {
+		errors += "<li>Perfect Cue Y position must be 0 or greater</li>"
+	}
+
+	newOptions.CueWidth, err = strconv.Atoi(r.FormValue("cue-width"))
+	errors += util.ValidateNumber(err, "Perfect Cue width")
+	if err == nil && newOptions.CueWidth < 1 {
+		errors += "<li>Perfect Cue width must be at least 1 pixel</li>"
+	}
+
+	newOptions.CueHeight, err = strconv.Atoi(r.FormValue("cue-height"))
+	errors += util.ValidateNumber(err, "Perfect Cue height")
+	if err == nil && newOptions.CueHeight < 1 {
+		errors += "<li>Perfect Cue height must be at least 1 pixel</li>"
+	}
+
 	// Strings, will not be validated
 	newOptions.HTTPUser = r.FormValue("HTTPUser")
 	newOptions.HTTPPassword = r.FormValue("HTTPPassword")

--- a/v4/cmd/sdl-clock/http.go
+++ b/v4/cmd/sdl-clock/http.go
@@ -3,10 +3,12 @@ package main
 import (
 	// "fmt"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	htmlTemplate "html/template"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -15,9 +17,11 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"text/template"
 	"time"
 
+	oscClient "gitlab.com/Depili/go-osc/osc"
 	"gitlab.com/clock-8001/clock-8001/v4/clock"
 	"gitlab.com/clock-8001/clock-8001/v4/util"
 )
@@ -37,6 +41,7 @@ func runHTTP() {
 	})
 	http.HandleFunc("/import", basicAuth(importHandler))
 	http.HandleFunc("/api/settime", basicAuth(setTimeHandler))
+	http.HandleFunc("/api/cue", basicAuth(cueTestHandler))
 
 	log.Printf("HTTP config: listening on %v", options.HTTPPort)
 	if err := http.ListenAndServe(options.HTTPPort, nil); err != nil {
@@ -560,6 +565,86 @@ func setTimeHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("OK"))
+}
+
+func localOSCClient() (*oscClient.Client, error) {
+	if options.EngineOptions == nil {
+		return nil, errors.New("engine options not initialized")
+	}
+	if options.EngineOptions.DisableOSC {
+		return nil, errors.New("osc control is disabled")
+	}
+
+	listenAddr := strings.TrimSpace(options.EngineOptions.ListenAddr)
+	if listenAddr == "" {
+		return nil, errors.New("osc listen address is empty")
+	}
+
+	portStr := ""
+	if strings.HasPrefix(listenAddr, ":") {
+		portStr = strings.TrimPrefix(listenAddr, ":")
+	} else {
+		_, p, err := net.SplitHostPort(listenAddr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid osc listen address %q: %w", listenAddr, err)
+		}
+		portStr = p
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid osc port %q: %w", portStr, err)
+	}
+
+	return oscClient.NewClient("127.0.0.1", port), nil
+}
+
+func cueTestHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	action := r.FormValue("action")
+	if action == "" {
+		http.Error(w, "Missing action parameter", http.StatusBadRequest)
+		return
+	}
+
+	client, err := localOSCClient()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var msg *oscClient.Message
+	switch action {
+	case "right":
+		msg = oscClient.NewMessage("/clock/cue/right")
+		msg.Append("")
+	case "left":
+		msg = oscClient.NewMessage("/clock/cue/left")
+		msg.Append("")
+	case "blank_on":
+		msg = oscClient.NewMessage("/clock/cue/blank")
+		msg.Append("")
+		msg.Append(true)
+	case "blank_off":
+		msg = oscClient.NewMessage("/clock/cue/blank")
+		msg.Append("")
+		msg.Append(false)
+	default:
+		http.Error(w, "Invalid action parameter", http.StatusBadRequest)
+		return
+	}
+
+	if err := client.Send(msg); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to send cue OSC message: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
 }
 
 func basicAuth(handler http.HandlerFunc) http.HandlerFunc {

--- a/v4/cmd/sdl-clock/http.go
+++ b/v4/cmd/sdl-clock/http.go
@@ -241,17 +241,13 @@ func saveHandler(w http.ResponseWriter, r *http.Request) {
 		errors += "<li>Perfect Cue Y position must be 0 or greater</li>"
 	}
 
-	newOptions.CueWidth, err = strconv.Atoi(r.FormValue("cue-width"))
-	errors += util.ValidateNumber(err, "Perfect Cue width")
-	if err == nil && newOptions.CueWidth < 1 {
-		errors += "<li>Perfect Cue width must be at least 1 pixel</li>"
+	newOptions.CueSize, err = strconv.Atoi(r.FormValue("cue-size"))
+	errors += util.ValidateNumber(err, "PerfectCue overlay size")
+	if err == nil && newOptions.CueSize < 1 {
+		errors += "<li>PerfectCue overlay size must be at least 1 pixel</li>"
 	}
-
-	newOptions.CueHeight, err = strconv.Atoi(r.FormValue("cue-height"))
-	errors += util.ValidateNumber(err, "Perfect Cue height")
-	if err == nil && newOptions.CueHeight < 1 {
-		errors += "<li>Perfect Cue height must be at least 1 pixel</li>"
-	}
+	newOptions.CueWidth = newOptions.CueSize
+	newOptions.CueHeight = newOptions.CueSize
 
 	// Strings, will not be validated
 	newOptions.HTTPUser = r.FormValue("HTTPUser")

--- a/v4/cmd/sdl-clock/main.go
+++ b/v4/cmd/sdl-clock/main.go
@@ -3,11 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/jessevdk/go-flags"
-	"github.com/veandco/go-sdl2/sdl"
-	"gitlab.com/clock-8001/clock-8001/v4/clock"
-	"gitlab.com/clock-8001/clock-8001/v4/debug"
-	"gitlab.com/clock-8001/clock-8001/v4/util"
 	"image/color"
 	"io"
 	"log"
@@ -19,6 +14,12 @@ import (
 	"text/template"
 	"time"
 	_ "time/tzdata"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/veandco/go-sdl2/sdl"
+	"gitlab.com/clock-8001/clock-8001/v4/clock"
+	"gitlab.com/clock-8001/clock-8001/v4/debug"
+	"gitlab.com/clock-8001/clock-8001/v4/util"
 )
 
 var parser = flags.NewParser(&options, flags.Default)

--- a/v4/cmd/sdl-clock/main.go
+++ b/v4/cmd/sdl-clock/main.go
@@ -184,7 +184,7 @@ func main() {
 			case *sdl.QuitEvent:
 				engine.Close()
 				os.Exit(0)
-	case *sdl.KeyboardEvent:
+			case *sdl.KeyboardEvent:
 				key := t.Keysym.Sym
 				if key == sdl.K_i {
 					infoHidden = !infoHidden
@@ -354,6 +354,18 @@ func parseOptions() {
 }
 
 func computeDerivedOptions() {
+	if options.CueSize < 1 {
+		if options.CueWidth > 0 {
+			options.CueSize = options.CueWidth
+		} else if options.CueHeight > 0 {
+			options.CueSize = options.CueHeight
+		} else {
+			options.CueSize = 150
+		}
+	}
+	options.CueWidth = options.CueSize
+	options.CueHeight = options.CueSize
+
 	switch options.Face {
 	case "max":
 		options.textClock = true


### PR DESCRIPTION
## Summary
- add web UI controls for PerfectCue overlay position and square size
- add a built-in PerfectCue overlay test button for hardware-free previewing
- clamp overlay drawing to the active renderer canvas so non-fullscreen mode stays visible
- update README to document the new PerfectCue overlay controls

## Details
- renames UI copy to use `PerfectCue` consistently
- moves the test button to the bottom of the PerfectCue section
- keeps older config values loading while using a single square-size control in the web UI

## Validation
- built from a clean GitHub clone on `pi5start.local`
- deployed to `piclock.local` and verified the installed binary checksum matched the build
- did not run test suites